### PR TITLE
add "root"

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -10,9 +10,9 @@ const serialize = (t, fn) => {
   const keys = getKeys(t)
   if (val && typeof val === 'object' && val.inherits) {
     const p = path(val) // memoized paths later
-    val = [ '@' ]
+    val = [ '@', 'root' ]
     let i = p.length
-    while (i--) { val[i + 1] = p[i] }
+    while (i--) { val[i + 2] = p[i] }
   }
   if (keys) {
     for (let i = 0, len = keys.length; i < len; i++) {


### PR DESCRIPTION
refs need `root` in `['@', 'root', target.path() ]` path