### PR TITLE
dont have same key twice

### DIFF
--- a/lib/struct/index.js
+++ b/lib/struct/index.js
@@ -24,7 +24,7 @@ const props = {
       : (p, key) => val.indexOf(key) === -1 && p.set(null, stamp)
     )
   },
-  props: (t, val, key, stamp) => {
+  props: (t, val, pkey, stamp) => {
     var props = t.props
     if (!props) {
       const previous = getProps(t)
@@ -115,4 +115,3 @@ struct.isDescriptor = true
 inject(struct, on)
 
 export default struct
-

--- a/lib/struct/types.js
+++ b/lib/struct/types.js
@@ -1,6 +1,6 @@
 import { create } from '../manipulate'
 import { getDefault } from '../get'
-console.log('require');
+
 const types = (t, val, pkey, stamp) => {
   if (!t.types) { t.types = {} }
   for (let key in val) {

--- a/lib/struct/types.js
+++ b/lib/struct/types.js
@@ -1,7 +1,7 @@
 import { create } from '../manipulate'
 import { getDefault } from '../get'
-
-const types = (t, val, key, stamp) => {
+console.log('require');
+const types = (t, val, pkey, stamp) => {
   if (!t.types) { t.types = {} }
   for (let key in val) {
     let prop = val[key]


### PR DESCRIPTION
brisky struct throws an error in safari because it uses "key" twice in the same function